### PR TITLE
Fix compile error

### DIFF
--- a/1/1-2-2_display_1.rs
+++ b/1/1-2-2_display_1.rs
@@ -1,24 +1,20 @@
+
 #![allow(unused)]
-​
-//#[derive(Debug)]
-struct Deep(Structure);
-​
 fn main() {
-    println!("{}",Structure(28));
-    println!("Now {} will print!", Deep(Structure(7)));
-    
-}
-​
 // Import (via `use`) the `fmt` module to make it available.
 // （`use`を使用し、）`fmt`モジュールをインポートします。
 use std::fmt;
-​
+
+
+println!("{}",Structure(28));
+println!("Now {} will print!", Deep(Structure(7)));
+
 // Define a structure for which `fmt::Display` will be implemented. This is
 // a tuple struct named `Structure` that contains an `i32`.
 // `fmt::Display`を実装するための構造体を定義します。
 // これは`Structure`という名前に紐付けられた、`i32`を含むタプルです。
 struct Structure(i32);
-​
+
 // To use the `{}` marker, the trait `fmt::Display` must be implemented
 // manually for the type.
 // `{}` というマーカーを使用するためには、
@@ -38,7 +34,10 @@ impl fmt::Display for Structure {
         write!(f, "{}", self.0)
     }
 }
-​
+
+//#[derive(Debug)]
+struct Deep(Structure);
+
 impl fmt::Display for Deep {
     // This trait requires `fmt` with this exact signature.
     // このトレイトは`fmt`が想定通りのシグネチャであることを要求します。
@@ -53,4 +52,5 @@ impl fmt::Display for Deep {
         // `write!`は`println!`に非常によく似た文法を使用していることに注目。
         write!(f, "{}", self.0)
     }
+}
 }


### PR DESCRIPTION
## 修正内容
- 1.2.2 display のファイルがコンパイルできない状態になっていたので解消しました。
    - 元の状態でコンパイルをすると、以下のようなエラーが出ていました。
```
$ rustc 1/1-2-2_display_1.rs
error: unknown start of token: \u{200b}
 --> 1/1-2-2_display_1.rs:2:1
  |
2 | 
  | ^

error: unknown start of token: \u{200b}
 --> 1/1-2-2_display_1.rs:5:1
  |
5 | 
  | ^

error: unknown start of token: \u{200b}
  --> 1/1-2-2_display_1.rs:11:1
   |
11 | 
   | ^

error: unknown start of token: \u{200b}
  --> 1/1-2-2_display_1.rs:15:1
   |
15 | 
   | ^

error: unknown start of token: \u{200b}
  --> 1/1-2-2_display_1.rs:21:1
   |
21 | 
   | ^

error: unknown start of token: \u{200b}
  --> 1/1-2-2_display_1.rs:41:1
   |
41 | 
   | ^

error: aborting due to 6 previous errors
```

現在はコンパイル・実行できるようになっています。
```
$ rustc 1/1-2-2_display_1.rs

$ ./1-2-2_display_1
28
Now 7 will print!
```