### PR TITLE
Remove `\u{200b}` to resolve `unknown start of token: \u{200b}` at compile

### DIFF
--- a/1/1-2-2_display_1.rs
+++ b/1/1-2-2_display_1.rs
@@ -1,24 +1,23 @@
 #![allow(unused)]
-​
+
+// Import (via `use`) the `fmt` module to make it available.
+// （`use`を使用し、）`fmt`モジュールをインポートします。
+use std::fmt;
+
 //#[derive(Debug)]
-struct Deep(Structure);
-​
+
 fn main() {
     println!("{}",Structure(28));
     println!("Now {} will print!", Deep(Structure(7)));
     
 }
-​
-// Import (via `use`) the `fmt` module to make it available.
-// （`use`を使用し、）`fmt`モジュールをインポートします。
-use std::fmt;
-​
+
 // Define a structure for which `fmt::Display` will be implemented. This is
 // a tuple struct named `Structure` that contains an `i32`.
 // `fmt::Display`を実装するための構造体を定義します。
 // これは`Structure`という名前に紐付けられた、`i32`を含むタプルです。
 struct Structure(i32);
-​
+
 // To use the `{}` marker, the trait `fmt::Display` must be implemented
 // manually for the type.
 // `{}` というマーカーを使用するためには、
@@ -38,7 +37,9 @@ impl fmt::Display for Structure {
         write!(f, "{}", self.0)
     }
 }
-​
+
+struct Deep(Structure);
+
 impl fmt::Display for Deep {
     // This trait requires `fmt` with this exact signature.
     // このトレイトは`fmt`が想定通りのシグネチャであることを要求します。


### PR DESCRIPTION
# 修正内容
1. コンパイル時に、`unknown start of token: \u{200b}`のエラーが発生していたため、該当箇所を削除しました。
2. `use` `struct`の位置を変更しました。

コンパイルが通り、実行できることをローカル端末で確認しました。
ご迷惑をおかけし失礼しました。よろしくお願いいたします。